### PR TITLE
商品編集機能

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :authenticate_user!, only: [:edit, :show]
 
   private
 

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -1,5 +1,6 @@
 class ListingsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
+  before_action :set_listing, only: [:show, :edit, :update]
 
   def index
     @listing = Listing.order('created_at DESC')
@@ -20,17 +21,15 @@ class ListingsController < ApplicationController
   end
 
     def show
-      @listing = Listing.find(params[:id])
     end
 
     def edit
-      @listing = Listing.find(params[:id])
+
     end
 
     def update
-      @listing = Listing.find(params[:id]) 
     if  @listing.update(listing_params)
-     redirect_to root_path
+     redirect_to listing_path(@listing.id)
     else
       render :edit
     end
@@ -40,6 +39,10 @@ class ListingsController < ApplicationController
 
   def listing_params
     params.require(:listing).permit(:product, :explanation, :category_id, :status_id, :delivery_id, :area_id, :day_id, :price, :image).merge(user_id: current_user.id)
+  end
+
+  def set_listing
+    @listing = Listing.find(params[:id])
   end
 
 

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -21,11 +21,16 @@ class ListingsController < ApplicationController
   end
 
     def show
+
     end
 
     def edit
-
+      if @listing.user == current_user
+        render :edit
+      else
+        redirect_to root_path
     end
+  end
 
     def update
     if  @listing.update(listing_params)

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -23,6 +23,19 @@ class ListingsController < ApplicationController
       @listing = Listing.find(params[:id])
     end
 
+    def edit
+      @listing = Listing.find(params[:id])
+    end
+
+    def update
+      @listing = Listing.find(params[:id]) 
+    if  @listing.update(listing_params)
+     redirect_to root_path
+    else
+      render :edit
+    end
+    end
+
   private
 
   def listing_params

--- a/app/views/listings/edit.html.erb
+++ b/app/views/listings/edit.html.erb
@@ -8,7 +8,7 @@ app/assets/stylesheets/items/new.css %>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @listing, local: true do |f| %>
-<%#= @listing.errors.full_messages %>
+
     <%= render 'shared/error_messages', model: f.object %>
 
     <%# 出品画像 %>

--- a/app/views/listings/edit.html.erb
+++ b/app/views/listings/edit.html.erb
@@ -1,0 +1,161 @@
+<%# cssは商品出品のものを併用しています。
+app/assets/stylesheets/items/new.css %>
+
+<div class="items-sell-contents">
+  <header class="items-sell-header">
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+  </header>
+  <div class="items-sell-main">
+    <h2 class="items-sell-title">商品の情報を入力</h2>
+    <%= form_with model: @listing, local: true do |f| %>
+<%#= @listing.errors.full_messages %>
+    <%= render 'shared/error_messages', model: f.object %>
+
+    <%# 出品画像 %>
+    <div class="img-upload">
+      <div class="weight-bold-text">
+        出品画像
+        <span class="indispensable">必須</span>
+      </div>
+      <div class="click-upload">
+        <p>
+          クリックしてファイルをアップロード
+        </p>
+        <%= f.file_field :image, id:"item-image" %>
+      </div>
+    </div>
+    <%# /出品画像 %>
+    <%# 商品名と商品説明 %>
+    <div class="new-items">
+      <div class="weight-bold-text">
+        商品名
+        <span class="indispensable">必須</span>
+      </div>
+      <%= f.text_area :product, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <div class="items-explain">
+        <div class="weight-bold-text">
+          商品の説明
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_area :explanation, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+      </div>
+    </div>
+    <%# /商品名と商品説明 %>
+
+    <%# 商品の詳細 %>
+    <div class="items-detail">
+      <div class="weight-bold-text">商品の詳細</div>
+      <div class="form">
+        <div class="weight-bold-text">
+          カテゴリー
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+        <div class="weight-bold-text">
+          商品の状態
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+      </div>
+    </div>
+    <%# /商品の詳細 %>
+
+    <%# 配送について %>
+    <div class="items-detail">
+      <div class="weight-bold-text question-text">
+        <span>配送について</span>
+        <a class="question" href="#">?</a>
+      </div>
+      <div class="form">
+        <div class="weight-bold-text">
+          配送料の負担
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:delivery_id, Delivery.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <div class="weight-bold-text">
+          発送元の地域
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:area_id, Area.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <div class="weight-bold-text">
+          発送までの日数
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:day_id, Day.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+      </div>
+    </div>
+    <%# /配送について %>
+
+    <%# 販売価格 %>
+    <div class="sell-price">
+      <div class="weight-bold-text question-text">
+        <span>販売価格<br>(¥300〜9,999,999)</span>
+        <a class="question" href="#">?</a>
+      </div>
+      <div>
+        <div class="price-content">
+          <div class="price-text">
+            <span>価格</span>
+            <span class="indispensable">必須</span>
+          </div>
+          <span class="sell-yen">¥</span>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+        </div>
+       
+        <div class="price-content">
+          <span>販売手数料 (10%)</span>
+          <span>
+            <span id='add-tax-price'></span>円
+          </span>
+        </div>
+        <div class="price-content">
+          <span>販売利益</span>
+          <span>
+            <span id='profit'></span>円
+          </span>
+        </div>
+      </div>
+    </div>
+    
+    <%# /販売価格 %>
+
+    <%# 注意書き %>
+    <div class="caution">
+      <p class="sentence">
+        <a href="#">禁止されている出品、</a>
+        <a href="#">行為</a>
+        を必ずご確認ください。
+      </p>
+      <p class="sentence">
+        またブランド品でシリアルナンバー等がある場合はご記載ください。
+        <a href="#">偽ブランドの販売</a>
+        は犯罪であり処罰される可能性があります。
+      </p>
+      <p class="sentence">
+        また、出品をもちまして
+        <a href="#">加盟店規約</a>
+        に同意したことになります。
+      </p>
+    </div>
+    <%# /注意書き %>
+    <%# 下部ボタン %>
+    <div class="sell-btn-contents">
+      <%= f.submit "変更する" ,class:"sell-btn" %>
+      <%=link_to 'もどる', root_path , class:"back-btn" %>
+    </div>
+    <%# /下部ボタン %>
+  </div>
+  <% end %>
+
+  <footer class="items-sell-footer">
+    <ul class="menu">
+      <li><a href="#">プライバシーポリシー</a></li>
+      <li><a href="#">フリマ利用規約</a></li>
+      <li><a href="#">特定商取引に関する表記</a></li>
+    </ul>
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <p class="inc">
+      ©︎Furima,Inc.
+    </p>
+  </footer>
+</div>

--- a/app/views/listings/show.html.erb
+++ b/app/views/listings/show.html.erb
@@ -24,7 +24,7 @@
     </div>
 
     <% if user_signed_in? && current_user.id == @listing.user_id %>
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+    <%= link_to '商品の編集', edit_listing_path, method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
    


### PR DESCRIPTION
（レビュー依頼）商品編集機能の実装
what　商品の詳細画面の編集ボタンから出品者が編集できる機能
why　出品した商品の編集、変更をできるようにする
gyazo
- 必要な情報を適切に入力すると、商品情報（商品画像・商品名・商品の状態など）を変更できること
-何も編集せずに更新をしても画像無しの商品にならないこと
- 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示されること（画像に関しては、表示されない状態で良い）
https://gyazo.com/c75a421ab5632cabf088716711b5780e
https://gyazo.com/ba478557ab4c2d91dd16337935722062
- ログイン状態の出品者だけが商品情報編集ページに遷移できること
https://gyazo.com/03537a8e60289e18a2bfd31d5d31b887
- エラーハンドリングができていること（適切では無い値が入力された場合、情報は保存されず、エラーメッセージを出力させること）
https://gyazo.com/d8516a62b3c44be1fcfac6b9c50a602a